### PR TITLE
Quobyte Client Helm Chart Enhancements

### DIFF
--- a/helm/quobyte-client/templates/quobyte-clients.yaml
+++ b/helm/quobyte-client/templates/quobyte-clients.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: quobyte-client-ds
-  namespace: default
+  namespace: {{ $.Release.Namespace }}
 spec:
   selector:
     matchLabels:
@@ -31,6 +31,8 @@ spec:
             # Corresponding volume mount must be one directory below this path
             # Example volumeMount is : /mnt/quobyte and clientMountPoint is /mnt/quobyte/mounts
             value:  {{ .Values.quobyte.clientMountPoint | quote }}
+          - name: QUOBYTE_CLIENT_OPTS
+            value: {{ .Values.quobyte.clientOptions | quote }}
           # Enabling access keys requires Quobyte version 3.0 or later
           - name: ENABLE_ACCESS_KEYS
             value: {{ .Values.quobyte.enableAccessKeys | quote }}  
@@ -54,6 +56,8 @@ spec:
           httpGet:
             port: 55000
             path: /
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
         command:
           - /bin/bash
           - -xec
@@ -77,7 +81,7 @@ spec:
                 echo "WARNING: The local filesystem does not support IMMUTABLE flag. Mount point pollution is possible."
               /usr/bin/mount.quobyte --hostname ${NODENAME} \
                 --http-port 55000 -f \
-                -d ${QUOBYTE_CLIENT_LOG_LEVEL} -l /dev/stdout ${OPTS} \
+                -d ${QUOBYTE_CLIENT_LOG_LEVEL} -l /dev/stdout ${OPTS} ${QUOBYTE_CLIENT_OPTS} \
                 --minidump-path /tmp/minidumps --allow-minidump-upload \
                 ${QUOBYTE_REGISTRY}/ ${QUOBYTE_MOUNT_POINT} ${ENABLE_ACCESS_CONTEXTS}
             fi
@@ -93,6 +97,19 @@ spec:
           preStop:
             exec:
               command: ["/bin/bash", "-xc", "umount -l ${QUOBYTE_MOUNT_POINT}"]
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       - name: quobyte-mount
         hostPath:

--- a/helm/quobyte-client/values.yaml
+++ b/helm/quobyte-client/values.yaml
@@ -13,7 +13,10 @@ quobyte:
   # The target directory where Quobyte client mounts all Quobyte volumes. 
   clientMountPoint: "/home/quobyte/mounts"
   # VolumeMountPoint is related to clientMountPoint, but one directory level below. 
-  volumeMountPoint: "/home/quobyte"  
+  volumeMountPoint: "/home/quobyte"
+  # Command line arguments to pass to mount.quobyte client command
+  clientOptions: ""
+
   # Registry service address of a matching Quobyte cluster. Default is the k8s service name 
   # of a Quobyte cluster installed in k8s.
   # Can be set to a string of comma-separated DNS A-records or IP addressses or 
@@ -21,4 +24,16 @@ quobyte:
   #registry: arecord1.example.com,arecord2.example.com,arecord3.example.com
   #registry: 192.168.2.1,192.168.2.2,192.168.2.3
   registry: _quobyte._tcp.quobyte.default.svc.cluster.local # Assumes Quobyte services are deployed in namespace "default".
+  
 
+hostNetwork: false
+nodeSelector: {}
+resources: {}
+  # limits:
+  #   cpu: 4
+  #   memory: 6Gi
+  # requests:
+  #   cpu: 1
+  #   memory: 4Gi
+tolerations: []
+affinity: {}


### PR DESCRIPTION
This PR adds the following enhancements to the Quobyte Client Helm Chart:

- Namespaces for Helm Releases
- nodeSelector, tolerations, and affiniity specification
- resources and hostNetwork specification
- Allow for command line options to be passed to mount.quobyte